### PR TITLE
Use per-cpu variable for struct free_list

### DIFF
--- a/aeon_balloc.h
+++ b/aeon_balloc.h
@@ -27,12 +27,23 @@ struct free_list {
 	u32		csum;		/* Protect integrity */
 };
 
+static inline struct free_list *aeon_alloc_free_lists(struct super_block *sb)
+{
+	return alloc_percpu(struct free_list);
+}
+
 static inline struct free_list *aeon_get_free_list(struct super_block *sb,
 						   int cpu)
 {
 	struct aeon_sb_info *sbi = AEON_SB(sb);
 
-	return &sbi->free_lists[cpu];
+	return per_cpu_ptr(sbi->free_lists, cpu);
+}
+
+static inline void aeon_free_free_lists(struct super_block *sb)
+{
+	struct aeon_sb_info *sbi = AEON_SB(sb);
+	free_percpu(sbi->free_lists);
 }
 
 int aeon_alloc_block_free_lists(struct super_block *sb);

--- a/balloc.c
+++ b/balloc.c
@@ -15,10 +15,7 @@ int aeon_alloc_block_free_lists(struct super_block *sb)
 	struct free_list *free_list;
 	int i;
 
-	sbi->free_lists = kcalloc(sbi->cpus,
-				  sizeof(struct free_list), GFP_KERNEL);
-	if (!sbi->free_lists)
-		return -ENOMEM;
+	sbi->free_lists = aeon_alloc_free_lists(sb);
 
 	for (i = 0; i < sbi->cpus; i++) {
 		free_list = aeon_get_free_list(sb, i);
@@ -45,7 +42,7 @@ void aeon_delete_free_lists(struct super_block *sb)
 		free_list->last_node = NULL;
 
 	}
-	kfree(sbi->free_lists);
+	aeon_free_free_lists(sb);
 	sbi->free_lists = NULL;
 }
 


### PR DESCRIPTION
Use per-cpu variable, which has a pointer to free_list structure to make work faster.
This change improves performance in varmail workload at least.

The result of varmail workload from filebench compared to old implementation:
679176.635 ops/s  <- 656294.018 ops/s 